### PR TITLE
Defaults & output

### DIFF
--- a/src/pgcheck/comparer/comparer_data.cpp
+++ b/src/pgcheck/comparer/comparer_data.cpp
@@ -70,6 +70,10 @@ double ComparerData::get_fastest_mockup_median_ms() {
   return fastest_mockup_median * 1000;
 }
 
+double ComparerData::get_fastest_mockup_mean_ms() {
+  return fastest_mockup_mean * 1000;
+}
+
 double ComparerData::get_slowdown() {
   return get_median() / fastest_mockup_median;
 }
@@ -82,11 +86,12 @@ std::string ComparerData::get_fastest_mockup() {
   return fastest_mockup;
 }
 
-void ComparerData::set_fastest_mockup(const std::string& mockup, double mockup_median) {
+void ComparerData::set_fastest_mockup(const std::string& mockup, double mockup_median, double mockup_mean) {
   if (fastest_mockup_median == 0 || mockup_median < fastest_mockup_median) {
     violation = true;
     fastest_mockup = mockup;
     fastest_mockup_median = mockup_median;
+    fastest_mockup_mean = mockup_mean;
   }
 }
 

--- a/src/pgcheck/comparer/comparer_data.h
+++ b/src/pgcheck/comparer/comparer_data.h
@@ -36,13 +36,12 @@ class ComparerData {
  private:
   bool violation = false;            // indicates if this object is affected by a guideline violation
   double fastest_mockup_median = 0;  // median of the fastest mockup which violates the guidelines
+  double fastest_mockup_mean = 0;    // mean of the fastest mockup which violates the guidelines
   std::string fastest_mockup;        // name of the fastest mockup
   std::vector<double> runtimes;      // a vector of runtimes
   TwoSampleTest *two_sample_test;    // the test object
-  double get_mean();
-  double get_variance();
 
- public:
+  public:
   explicit ComparerData(const std::vector<double>& rts);
   ComparerData(const std::vector<double>& rts, int test_id);
   bool is_violated();
@@ -51,6 +50,8 @@ class ComparerData {
    */
   bool get_violation(ComparerData alt);
   int get_size();
+  double get_mean();
+  double get_variance();
   double get_mean_ms();
   double get_median();
   double get_median_ms();
@@ -59,6 +60,7 @@ class ComparerData {
    */
   double get_critical_value(ComparerData alt);
   double get_fastest_mockup_median_ms();
+  double get_fastest_mockup_mean_ms();
   double get_slowdown();
   /**
    * @return slowdown between this and mockup_median
@@ -72,7 +74,7 @@ class ComparerData {
   /**
    * overwrites fastest mockup if mockup_median is smaller than current
    */
-  void set_fastest_mockup(const std::string& mockup, double mockup_median);
+  void set_fastest_mockup(const std::string& mockup, double mockup_median, double mockup_mean);
 };
 
 #endif  // SRC_PGCHECK_COMPARER_COMPARER_DATA_H_

--- a/src/pgcheck/comparer/comparer_factory.cpp
+++ b/src/pgcheck/comparer/comparer_factory.cpp
@@ -27,32 +27,32 @@ std::unique_ptr<PGDataComparer>
 ComparerFactory::create_comparer(int comparer_id, int test_type, std::string mpi_coll_name, int nnodes, int ppn) {
   std::unique_ptr<PGDataComparer> comparer;
   switch (comparer_id) {
-    case 0:
+    case ComparerType::SIMPLE:
       comparer = std::make_unique<SimpleComparer>(mpi_coll_name, nnodes, ppn);
       break;
-    case 1:
+    case ComparerType::ABS_RUNTIME:
       comparer = std::make_unique<AbsRuntimeComparer>(mpi_coll_name, nnodes, ppn);
       break;
-    case 2:
+    case ComparerType::REL_RUNTIME:
       comparer = std::make_unique<RelRuntimeComparer>(mpi_coll_name, nnodes, ppn);
       break;
-    case 3:
+    case ComparerType::VIOLATION:
       comparer = std::make_unique<ViolationComparer>(test_type, mpi_coll_name, nnodes, ppn);
       break;
-    case 4:
+    case ComparerType::DETAILED_VIOLATION:
       comparer = std::make_unique<DetailedViolationComparer>(test_type, mpi_coll_name, nnodes, ppn);
       break;
-    case 5:
-      comparer = std::make_unique<GroupedViolationComparer>(test_type, mpi_coll_name, nnodes, ppn);
+    case ComparerType::RAW:
+      comparer = std::make_unique<RawComparer>(mpi_coll_name, nnodes, ppn);
       break;
     default:
-    case 6:
-      comparer = std::make_unique<RawComparer>(mpi_coll_name, nnodes, ppn);
+    case ComparerType::GROUPED_VIOLATION:
+      comparer = std::make_unique<GroupedViolationComparer>(test_type, mpi_coll_name, nnodes, ppn);
       break;
   }
   return comparer;
 }
 
 int ComparerFactory::get_number_of_comparers() {
-  return 7;
+  return ComparerType::NUM_COMPARERS;
 }

--- a/src/pgcheck/comparer/comparer_factory.h
+++ b/src/pgcheck/comparer/comparer_factory.h
@@ -38,6 +38,19 @@
 
 class ComparerFactory {
  public:
+  enum ComparerType {
+    SIMPLE,
+    ABS_RUNTIME,
+    REL_RUNTIME,
+    VIOLATION,
+    DETAILED_VIOLATION,
+    GROUPED_VIOLATION,
+    RAW,
+    NUM_COMPARERS
+  };
+
+  static constexpr auto DEFAULT_COMPARER = ComparerType::GROUPED_VIOLATION;
+
   static std::unique_ptr <PGDataComparer>
   create_comparer(int comparer_id, int test_type, std::string mpi_coll_name, int nnodes, int ppn);
   static int get_number_of_comparers();

--- a/src/pgcheck/comparer/runtime/abs_runtime_comparer.cpp
+++ b/src/pgcheck/comparer/runtime/abs_runtime_comparer.cpp
@@ -27,8 +27,8 @@ AbsRuntimeComparer::AbsRuntimeComparer(const std::string &mpi_coll_name, int nno
     PGDataComparer(mpi_coll_name, nnodes, ppn) {}
 
 PGDataTable AbsRuntimeComparer::get_results() {
-  std::vector <std::string> col_names = {"message_size", "mockup", "median_ms"};
-  std::vector<int> col_widths = {15, 50, 10};
+  std::vector <std::string> col_names = {"message_size", "mockup", "median_ms", "mean_ms"};
+  std::vector<int> col_widths = {15, 50, 10, 10};
   PGDataTable res(mpi_coll_name, col_names);
   StatisticsUtils<double> statisticsUtils;
 
@@ -39,7 +39,8 @@ PGDataTable AbsRuntimeComparer::get_results() {
       std::unordered_map <std::string, std::string> row;
       row["message_size"] = std::to_string(count);
       row["mockup"] = mockup_data.first;
-      row["median_ms"] = std::to_string(statisticsUtils.mean(rts) * 1000);
+      row["median_ms"] = std::to_string(statisticsUtils.median(rts) * 1000);
+      row["mean_ms"] = std::to_string(statisticsUtils.mean(rts) * 1000);
       res.add_row(row);
     }
   }

--- a/src/pgcheck/comparer/runtime/rel_runtime_comparer.cpp
+++ b/src/pgcheck/comparer/runtime/rel_runtime_comparer.cpp
@@ -27,8 +27,8 @@ RelRuntimeComparer::RelRuntimeComparer(const std::string &mpi_coll_name, int nno
     PGDataComparer(mpi_coll_name, nnodes, ppn) {}
 
 PGDataTable RelRuntimeComparer::get_results() {
-  std::vector <std::string> col_names = {"message_size", "mockup", "relative_runtime"};
-  std::vector<int> col_widths = {15, 50, 20};
+  std::vector <std::string> col_names = {"message_size", "mockup", "rel_median", "rel_mean"};
+  std::vector<int> col_widths = {15, 50, 20, 20};
   PGDataTable res(mpi_coll_name, col_names);
   StatisticsUtils<double> statisticsUtils;
 
@@ -40,7 +40,8 @@ PGDataTable RelRuntimeComparer::get_results() {
     std::unordered_map <std::string, std::string> row;
     row["message_size"] = std::to_string(count);
     row["mockup"] = "default";
-    row["relative_runtime"] = std::to_string(1);
+    row["rel_median"] = std::to_string(1);
+    row["rel_mean"] = std::to_string(1);
     res.add_row(row);
   }
 
@@ -54,7 +55,8 @@ PGDataTable RelRuntimeComparer::get_results() {
       std::unordered_map <std::string, std::string> row;
       row["message_size"] = std::to_string(count);
       row["mockup"] = mockup_data.first;
-      row["relative_runtime"] = std::to_string(def_res.at(count) / statisticsUtils.median(rts));
+      row["rel_median"] = std::to_string(statisticsUtils.median(rts) / def_res.at(count));
+      row["rel_mean"] = std::to_string(statisticsUtils.mean(rts) / def_res.at(count));
       res.add_row(row);
     }
   }

--- a/src/pgcheck/comparer/simple_comparer.cpp
+++ b/src/pgcheck/comparer/simple_comparer.cpp
@@ -29,7 +29,7 @@ SimpleComparer::SimpleComparer(const std::string& mpi_coll_name, int nnodes, int
     PGDataComparer(mpi_coll_name, nnodes, ppn) {}
 
 PGDataTable SimpleComparer::get_results() {
-  std::vector <std::string> col_names = {"mockup", "count", "runtime"};
+  std::vector <std::string> col_names = {"mockup", "count", "mean_ms"};
   PGDataTable res(mpi_coll_name, col_names);
   StatisticsUtils<double> statisticsUtils;
   for (auto &mockup_data : mockup2data) {
@@ -39,7 +39,7 @@ PGDataTable SimpleComparer::get_results() {
       std::unordered_map <std::string, std::string> row;
       row["mockup"] = mockup_data.first;
       row["count"] = std::to_string(count);
-      row["runtime"] = std::to_string(statisticsUtils.mean(rts) * 1000);
+      row["mean_ms"] = std::to_string(statisticsUtils.mean(rts) * 1000);
       res.add_row(row);
     }
   }

--- a/src/pgcheck/comparer/statistical_test/two_sample_test_factory.cpp
+++ b/src/pgcheck/comparer/statistical_test/two_sample_test_factory.cpp
@@ -26,14 +26,14 @@
 TwoSampleTest *TwoSampleTestFactory::create_two_sample_test(int test_id) {
   TwoSampleTest *two_sample_test;
   switch (test_id) {
-    default:
-    case 0:
+    case TwoSampleTestType::TTEST:
       two_sample_test = new TTest();
       break;
-    case 1:
+    case TwoSampleTestType::WILCOXON_RANK_SUM:
       two_sample_test = new WilcoxonRankSum();
       break;
-    case 2:
+    default:
+    case TwoSampleTestType::WILCOXON_MANN_WHITNEY:
       two_sample_test = new WilcoxonMannWhitney();
       break;
   }

--- a/src/pgcheck/comparer/statistical_test/two_sample_test_factory.h
+++ b/src/pgcheck/comparer/statistical_test/two_sample_test_factory.h
@@ -31,6 +31,12 @@
 
 class TwoSampleTestFactory {
  public:
+  enum TwoSampleTestType {
+    TTEST,
+    WILCOXON_RANK_SUM,
+    WILCOXON_MANN_WHITNEY
+  };
+
   static TwoSampleTest *create_two_sample_test(int test_id);
 };
 

--- a/src/pgcheck/comparer/violation/grouped_violation_comparer.cpp
+++ b/src/pgcheck/comparer/violation/grouped_violation_comparer.cpp
@@ -23,7 +23,19 @@
 
 #include "grouped_violation_comparer.h"
 
-static std::vector<int> col_widths = {25, 15, 5, 5, 5, 15, 10, 50, 15};
+static std::vector<int> col_widths = {
+  25, // collective
+  15, // count
+  5,  // N
+  5,  // ppn
+  5,  // n
+  15, // default_median
+  15, // default_mean
+  10, // slowdown
+  50, // fastest_mockup
+  15, // mockup_median
+  15  // mockup_mean
+};
 
 GroupedViolationComparer::GroupedViolationComparer(int test_type,
                                                    const std::string &mpi_coll_name,
@@ -32,9 +44,10 @@ GroupedViolationComparer::GroupedViolationComparer(int test_type,
     PGDataComparer(mpi_coll_name, nnodes, ppn), test_type(test_type) {}
 
 PGDataTable GroupedViolationComparer::get_results() {
-  std::vector <std::string> col_names = {"collective", "count", "N", "ppn", "n", "default_median", "slowdown",
+  std::vector <std::string> col_names = {"collective", "count", "N", "ppn", "n",
+                                         "default_median", "default_mean", "slowdown",
                                          "fastest_mockup",
-                                         "mockup_median"};
+                                         "mockup_median", "mockup_mean"};
   PGDataTable res(mpi_coll_name, col_names);
   std::map<int, ComparerData> def_res;
   auto &default_data = mockup2data.at("default");
@@ -55,7 +68,7 @@ PGDataTable GroupedViolationComparer::get_results() {
       ComparerData alt_res(rts);
 
       if (def_res.at(count).get_violation(alt_res)) {
-        def_res.at(count).set_fastest_mockup(mockup_data.first, alt_res.get_median());
+        def_res.at(count).set_fastest_mockup(mockup_data.first, alt_res.get_median(), alt_res.get_mean());
       }
     }
   }
@@ -69,11 +82,13 @@ PGDataTable GroupedViolationComparer::get_results() {
     row["ppn"] = std::to_string(ppn);
     row["n"] = std::to_string(data.get_size());
     row["default_median"] = std::to_string(data.get_median_ms());
+    row["default_mean"] = std::to_string(data.get_mean_ms());
 
     if (data.is_violated()) {
       row["slowdown"] = std::to_string(data.get_slowdown());
       row["fastest_mockup"] = data.get_fastest_mockup();
       row["mockup_median"] = std::to_string(data.get_fastest_mockup_median_ms());
+      row["mockup_mean"] = std::to_string(data.get_fastest_mockup_mean_ms());
       if (has_barrier_time()) {
         // don't forget, barrier time is in 's'
         if (data.get_median_ms() - data.get_fastest_mockup_median_ms() < get_barrier_time() * 1000) {
@@ -84,6 +99,7 @@ PGDataTable GroupedViolationComparer::get_results() {
       row["slowdown"] = "";
       row["fastest_mockup"] = "";
       row["mockup_median"] = "";
+      row["mockup_mean"] = "";
     }
 
     res.add_row(row);

--- a/src/pgcheck/pgcheck_options.cpp
+++ b/src/pgcheck/pgcheck_options.cpp
@@ -139,9 +139,9 @@ int PGCheckOptions::parse(int argc, char *argv[], bool is_root) {
   optind = 1;
   opterr = 1;
 
-  // comparer 5 is default
+  // set default comparer if none is given
   if (comparer_list.size() < 1) {
-    comparer_list.push_back(5);
+    comparer_list.push_back(ComparerFactory::DEFAULT_COMPARER);
   }
 
   // unique and sorted comparer list if list has multiple entries
@@ -179,17 +179,21 @@ std::string PGCheckOptions::get_usage_string() {
   usage << "OPTIONS:" << std::endl;
   usage << std::setw(36) << std::left << "  ?, -h, --help" << "Display this information." << std::endl;
   usage << std::setw(36) << std::left << "  -c, --comp-list={0|1|2|3|4|5|6}"
-        << "Specify the comparer type ("
-        << "0=Simple|"
-        << "1=Absolute Median|"
-        << "2=Relative Median|"
-        << "3=Violation-Test|"
-        << "4=Detailed Violation-Test|"
-        << "5=Grouped Violation-Test|"
-        << "6=Raw Data)."
+        << "Specify the comparer type: "
+        << "0=Simple | "
+        << "1=Absolute Median | "
+        << "2=Relative Median | "
+        << "3=Violation-Test | "
+        << "4=Detailed Violation-Test | "
+        << "5=Grouped Violation-Test (default) | "
+        << "6=Raw Data."
         << std::endl;
   usage << std::setw(36) << std::left << "  -t, --test {0|1|2}"
-        << "Specify the test type (0=T-Test|1=Wilcoxon-Rank-Sum-Test|2=Wilcoxon-Mann-Whitney)." << std::endl;
+        << "Specify the test type: "
+        << "0=T-Test | "
+        << "1=Wilcoxon-Rank-Sum-Test | "
+        << "2=Wilcoxon-Mann-Whitney (default)."
+        << std::endl;
   usage << std::setw(36) << std::left << "  -o, --output <path>" << "Specify an existing output folder."
         << std::endl;
   usage << std::setw(36) << std::left << "  -m, --merge"


### PR DESCRIPTION
- Changed default test to Wilcoxon-Mann-Whitney
- Updated the help message to show the default comparer and test
- When parsing the args, there was a hardcoded default for the comparer (5). Changed that to a proper variable in the comparer factory
- Factories now use enums
- Comparers show now both the mean and the median